### PR TITLE
Fix negative other count calculation

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_stats/field_top_values.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_stats/field_top_values.tsx
@@ -131,6 +131,11 @@ export const getBucketsValuesCount = (
   return buckets?.reduce((prev, bucket) => bucket.count + prev, 0) || 0;
 };
 
-export const getOtherCount = (bucketsValuesCount: number, sampledValuesCount: number): number => {
-  return sampledValuesCount && bucketsValuesCount ? sampledValuesCount - bucketsValuesCount : 0;
+export const getOtherCount = (
+  bucketsValuesCount: number,
+  sampledValuesCount: number
+): number => {
+  return sampledValuesCount && bucketsValuesCount
+    ? Math.max(sampledValuesCount - bucketsValuesCount, 0)
+    : 0;
 };


### PR DESCRIPTION
## Summary
- prevent negative values when computing otherCount in field stats

## Testing
- `node scripts/eslint src/platform/packages/shared/kbn-unified-field-list/src/components/field_stats/field_top_values.tsx` *(fails: Cannot find module 'require-in-the-middle')*

------
https://chatgpt.com/codex/tasks/task_e_684108e94fd8832497cff88eb6eae9c7